### PR TITLE
This fixes #8

### DIFF
--- a/Stack/Core/Stack/Constants/DataTypes.Helpers.cs
+++ b/Stack/Core/Stack/Constants/DataTypes.Helpers.cs
@@ -35,7 +35,7 @@ namespace Opc.Ua
 
 			foreach (FieldInfo field in fields)
 			{
-                if (identifier == (int)field.GetValue(typeof(DataTypes)))
+                if (identifier == (uint)field.GetValue(typeof(DataTypes)))
 				{
 					return field.Name;
 				}


### PR DESCRIPTION
Fix for InvalidCastException in DataTypes.GetBrowseName method.