### PR TITLE
Added ReturnDiagnosticsFlags property and overloaded Call method for Session.

### DIFF
--- a/SampleApplications/SampleLibraries/Client/Session.cs
+++ b/SampleApplications/SampleLibraries/Client/Session.cs
@@ -3170,6 +3170,18 @@ namespace Opc.Ua.Client
         /// <returns>The list of output argument values.</returns>
         public IList<object> Call(NodeId objectId, NodeId methodId, params object[] args)
         {
+            return this.Call(null,objectId, methodId, args);
+        }
+        /// <summary>
+        /// Calls the specified method and returns the output arguments.
+        /// </summary>
+        /// <param name="requestHeader">Request header for the call of the method.</param>
+        /// <param name="objectId">The NodeId of the object that provides the method.</param>
+        /// <param name="methodId">The NodeId of the method to call.</param>
+        /// <param name="args">The input arguments.</param>
+        /// <returns>The list of output argument values.</returns>
+        public IList<object> Call(RequestHeader requestHeader,NodeId objectId, NodeId methodId, params object[] args)
+        {
             VariantCollection inputArguments = new VariantCollection();
             
             if (args != null)
@@ -3193,7 +3205,7 @@ namespace Opc.Ua.Client
             DiagnosticInfoCollection diagnosticInfos;
 
             ResponseHeader responseHeader = Call(
-                null,
+                requestHeader,
                 requests,
                 out results,
                 out diagnosticInfos);

--- a/Stack/Core/Stack/Generated/Opc.Ua.Constants.cs
+++ b/Stack/Core/Stack/Generated/Opc.Ua.Constants.cs
@@ -1556,6 +1556,39 @@ namespace Opc.Ua
     }
     #endregion
 
+    #region ReturnDiagnostics flags
+    /// <summary>
+    /// An enum providing symbolic names for ReturnDiagnostics flags (see: RequestHeader).
+    /// </summary>
+    [Flags]
+    public enum ReturnDiagnostics : UInt32
+    {
+        None = 0,
+
+        ServiceLevel_SymbolicId = 0x00000001,
+        ServiceLevel_LocalizedText = 0x00000002,
+        ServiceLevel_AdditionalInfo = 0x00000004,
+        ServiceLevel_InnerStatusCode = 0x00000008,
+        ServiceLevel_InnerDiagnostics = 0x00000010,
+        OperationLevel_SymbolicId = 0x00000020,
+        OperationLevel_LocalizedText = 0x00000040,
+        OperationLevel_AdditionalInfo = 0x00000080,
+        OperationLevel_InnerStatusCode = 0x00000100,
+        OperationLevel_InnerDiagnostics = 0x00000200,
+
+        All = ServiceLevel_SymbolicId
+            | ServiceLevel_LocalizedText
+            | ServiceLevel_AdditionalInfo
+            | ServiceLevel_InnerStatusCode
+            | ServiceLevel_InnerDiagnostics
+            | OperationLevel_SymbolicId
+            | OperationLevel_LocalizedText
+            | OperationLevel_AdditionalInfo
+            | OperationLevel_InnerStatusCode
+            | OperationLevel_InnerDiagnostics
+    }
+    #endregion
+
     #region Method Identifiers
     /// <summary>
     /// A class that declares constants for all Methods in the Model Design.

--- a/Stack/Core/Stack/Generated/Opc.Ua.Constants.cs
+++ b/Stack/Core/Stack/Generated/Opc.Ua.Constants.cs
@@ -1556,39 +1556,6 @@ namespace Opc.Ua
     }
     #endregion
 
-    #region ReturnDiagnostics flags
-    /// <summary>
-    /// An enum providing symbolic names for ReturnDiagnostics flags (see: RequestHeader).
-    /// </summary>
-    [Flags]
-    public enum ReturnDiagnostics : UInt32
-    {
-        None = 0,
-
-        ServiceLevel_SymbolicId = 0x00000001,
-        ServiceLevel_LocalizedText = 0x00000002,
-        ServiceLevel_AdditionalInfo = 0x00000004,
-        ServiceLevel_InnerStatusCode = 0x00000008,
-        ServiceLevel_InnerDiagnostics = 0x00000010,
-        OperationLevel_SymbolicId = 0x00000020,
-        OperationLevel_LocalizedText = 0x00000040,
-        OperationLevel_AdditionalInfo = 0x00000080,
-        OperationLevel_InnerStatusCode = 0x00000100,
-        OperationLevel_InnerDiagnostics = 0x00000200,
-
-        All = ServiceLevel_SymbolicId
-            | ServiceLevel_LocalizedText
-            | ServiceLevel_AdditionalInfo
-            | ServiceLevel_InnerStatusCode
-            | ServiceLevel_InnerDiagnostics
-            | OperationLevel_SymbolicId
-            | OperationLevel_LocalizedText
-            | OperationLevel_AdditionalInfo
-            | OperationLevel_InnerStatusCode
-            | OperationLevel_InnerDiagnostics
-    }
-    #endregion
-
     #region Method Identifiers
     /// <summary>
     /// A class that declares constants for all Methods in the Model Design.

--- a/Stack/Core/Stack/Generated/Opc.Ua.DataTypes.cs
+++ b/Stack/Core/Stack/Generated/Opc.Ua.DataTypes.cs
@@ -4519,6 +4519,15 @@ namespace Opc.Ua
         }
 
         /// <summary>
+        /// A wrapper for 'ReturnDiagnostics' property in order to use symbolic names instead of magic values.
+        /// </summary>
+        public ReturnDiagnostics ReturnDiagnosticsFlags
+        {
+            get { return (ReturnDiagnostics)this.ReturnDiagnostics; }
+            set { this.ReturnDiagnostics = (uint)value; }
+        }
+
+        /// <summary>
         /// Identifies an entry in the client audit log.
         /// </summary>
         [DataMember(Name = "AuditEntryId", IsRequired = false, Order = 5)]

--- a/Stack/Core/Stack/Generated/Opc.Ua.DataTypes.cs
+++ b/Stack/Core/Stack/Generated/Opc.Ua.DataTypes.cs
@@ -4521,9 +4521,9 @@ namespace Opc.Ua
         /// <summary>
         /// A wrapper for 'ReturnDiagnostics' property in order to use symbolic names instead of magic values.
         /// </summary>
-        public ReturnDiagnostics ReturnDiagnosticsFlags
+        public DiagnosticsMasks ReturnDiagnosticsFlags
         {
-            get { return (ReturnDiagnostics)this.ReturnDiagnostics; }
+            get { return (DiagnosticsMasks)this.ReturnDiagnostics; }
             set { this.ReturnDiagnostics = (uint)value; }
         }
 


### PR DESCRIPTION
Just two small features added for more comfortable working with the stack -- first ReturnDiagnosticsFlags property wrapper in RequestHeader to use symbolic names instead of magic values (ints), and second overloaded "Call" method for "Session" class, which accepts additional param "RequestHeader".