### PR TITLE
Fixes reentrancy issue in SessionReconnectHandler (issue #90)

### DIFF
--- a/SampleApplications/SampleLibraries/Client/SessionReconnectHandler.cs
+++ b/SampleApplications/SampleLibraries/Client/SessionReconnectHandler.cs
@@ -2,7 +2,7 @@
  * Copyright (c) 2005-2016 The OPC Foundation, Inc. All rights reserved.
  *
  * OPC Foundation MIT License 1.00
- * 
+ *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
  * files (the "Software"), to deal in the Software without
@@ -11,7 +11,7 @@
  * copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following
  * conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -36,7 +36,7 @@ namespace Opc.Ua.Client
     /// Attempts to reconnect to the server.
     /// </summary>
     public class SessionReconnectHandler : IDisposable
-    {        
+    {
         #region IDisposable Members
         /// <summary>
         /// Frees any unmanaged resources.
@@ -63,8 +63,8 @@ namespace Opc.Ua.Client
                 }
             }
         }
-        #endregion       
-                
+        #endregion
+
         #region Public Methods
         /// <summary>
         /// Gets the session managed by the handler.

--- a/SampleApplications/SampleLibraries/Client/SessionReconnectHandler.cs
+++ b/SampleApplications/SampleLibraries/Client/SessionReconnectHandler.cs
@@ -28,10 +28,7 @@
  * ======================================================================*/
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
-using Opc.Ua;
 
 namespace Opc.Ua.Client
 {

--- a/SampleApplications/SampleLibraries/Client/SessionReconnectHandler.cs
+++ b/SampleApplications/SampleLibraries/Client/SessionReconnectHandler.cs
@@ -94,7 +94,7 @@ namespace Opc.Ua.Client
                 m_reconnectFailed = false;
                 m_reconnectPeriod = reconnectPeriod;
                 m_callback = callback;
-                m_reconnectTimer = new System.Threading.Timer(OnReconnect, null, reconnectPeriod, reconnectPeriod);
+                m_reconnectTimer = new System.Threading.Timer(OnReconnect, null, reconnectPeriod, Timeout.Infinite);
             }
         }
         #endregion
@@ -132,6 +132,16 @@ namespace Opc.Ua.Client
             catch (Exception exception)
             {
                 Utils.Trace(exception, "Unexpected error during reconnect.");
+            }
+            finally
+            {
+                lock (m_lock)
+                {
+                    if (m_reconnectTimer != null)
+                    {
+                        m_reconnectTimer.Change(m_reconnectPeriod, Timeout.Infinite);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This pull request fixes reentrancy issue as specified in #90. It stops the timer before reconnection attempt and eventually starts is again if the attempt was not successful.