### PR TITLE
Changed SDK source code to enable support for sending/receiving certificate chains

### DIFF
--- a/Stack/Core/Stack/Client/SessionChannel.cs
+++ b/Stack/Core/Stack/Client/SessionChannel.cs
@@ -88,7 +88,7 @@ namespace Opc.Ua
         /// <param name="clientCertificates">The client certificates.</param>
         /// <param name="messageContext">The message context.</param>
         /// <returns></returns>
-        /*public static ITransportChannel Create(
+        public static ITransportChannel Create(
             ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
@@ -127,7 +127,7 @@ namespace Opc.Ua
 
             return channel;
         }
-        */
+        
 
         #if !SILVERLIGHT
         /// <summary>

--- a/Stack/Core/Stack/Client/WcfChannelBase.cs
+++ b/Stack/Core/Stack/Client/WcfChannelBase.cs
@@ -822,7 +822,7 @@ namespace Opc.Ua
         /// <param name="clientCertificates">The client certificates.</param>
         /// <param name="messageContext">The message context.</param>
         /// <returns></returns>
-        /*public static ITransportChannel CreateUaBinaryChannel(
+        public static ITransportChannel CreateUaBinaryChannel(
             ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
@@ -916,8 +916,8 @@ namespace Opc.Ua
             settings.Configuration = endpointConfiguration;
             if (clientCertificates != null && clientCertificates.Count > 0)
             {
-                settings.ClientCertificate = clientCertificates[0];
-                //settings.ClientCertificateChain = clientCertificates;
+                //settings.ClientCertificate = clientCertificates[0];
+                settings.ClientCertificateChain = clientCertificates;
             }
 
             if (description.ServerCertificate != null && description.ServerCertificate.Length > 0)
@@ -966,7 +966,7 @@ namespace Opc.Ua
 
             return channel;
         }
-        */
+        
 
         /// <summary>
         /// Handles the Opened event of the InnerChannel control.
@@ -1358,7 +1358,7 @@ namespace Opc.Ua
         /// <param name="binding">The binding.</param>
         /// <param name="clientCertificates">The client certificates.</param>
         /// <param name="configurationName">Name of the configuration.</param>
-        /*public void Initialize(
+        public void Initialize(
             ApplicationConfiguration configuration,
             EndpointDescription description,
             EndpointConfiguration endpointConfiguration,
@@ -1525,7 +1525,7 @@ namespace Opc.Ua
                 communicationObject.Opened += new EventHandler(InnerChannel_Opened);
             }
         }
-        */
+        
 #endif
         #endregion
 

--- a/Stack/Core/Stack/Server/ServerBase.cs
+++ b/Stack/Core/Stack/Server/ServerBase.cs
@@ -592,7 +592,7 @@ namespace Opc.Ua
         /// <summary>
         /// Gets the instance certificate chain.
         /// </summary>
-        /*protected X509Certificate2Collection InstanceCertificateChain
+        protected X509Certificate2Collection InstanceCertificateChain
         {
             get
             {
@@ -603,7 +603,7 @@ namespace Opc.Ua
             {
                 m_instanceCertificateChain = value;
             }
-        }*/
+        }
 
         /// <summary>
         /// The non-configurable properties for the server.
@@ -798,17 +798,28 @@ namespace Opc.Ua
                             "Server does not have an instance certificate assigned." );
                     }
 
-                    description.ServerCertificate = InstanceCertificate.RawData;
+                    //description.ServerCertificate = InstanceCertificate.RawData;
 
-                    //if (InstanceCertificateChain != null)
-                    //{
-                    //    List<byte> certificateChainList = new List<byte>();
-                    //    for (int i = 0; i < InstanceCertificateChain.Count; i++)
-                    //    {
-                    //        certificateChainList.AddRange(InstanceCertificateChain[i].RawData);
-                    //    }
-                    //    description.ServerCertificate = certificateChainList.ToArray();
-                    //}
+                    if (InstanceCertificateChain != null)
+                    {
+                        List<byte> certificateChainList = new List<byte>();
+
+                        //build certificate chain only if the respective option is true in server configuration
+                        System.Xml.XmlElement configExtension = configuration.Extensions.Find(e => e.Name.Equals("SendCertificateChain"));
+                        if ((configExtension == null || (configExtension != null && configExtension.InnerText.Equals("False"))))
+                        {
+                            certificateChainList.AddRange(InstanceCertificateChain[0].RawData);
+                        }
+                        else
+                        {
+                            for (int i = 0; i < InstanceCertificateChain.Count; i++)
+                            {
+                                certificateChainList.AddRange(InstanceCertificateChain[i].RawData);
+                            }
+                        }
+
+                        description.ServerCertificate =  certificateChainList.ToArray();
+                    }
                 }
 
                 endpoints.Add(description);
@@ -952,17 +963,28 @@ namespace Opc.Ua
 
                     if (requireEncryption)
                     {
-                        description.ServerCertificate = InstanceCertificate.RawData;
+                        //description.ServerCertificate = InstanceCertificate.RawData;
 
-                        //if (InstanceCertificateChain != null)
-                        //{
-                        //    List<byte> certificateChainList = new List<byte>();
-                        //    for (int i = 0; i < InstanceCertificateChain.Count; i++)
-                        //    {
-                        //        certificateChainList.AddRange(InstanceCertificateChain[i].RawData);
-                        //    }
-                        //    description.ServerCertificate = certificateChainList.ToArray();
-                        //}
+                        if (InstanceCertificateChain != null)
+                        {
+                            List<byte> certificateChainList = new List<byte>();
+
+                            //build certificate chain only if the respective option is true in server configuration
+                            System.Xml.XmlElement configExtension = configuration.Extensions.Find(e => e.Name.Equals("SendCertificateChain"));
+                            if ((configExtension == null || (configExtension != null && configExtension.InnerText.Equals("False"))))
+                            {
+                                certificateChainList.AddRange(InstanceCertificateChain[0].RawData);
+                            }
+                            else
+                            {
+                                for (int i = 0; i < InstanceCertificateChain.Count; i++)
+                                {
+                                    certificateChainList.AddRange(InstanceCertificateChain[i].RawData);
+                                }
+                            }
+                            
+                            description.ServerCertificate =   certificateChainList.ToArray();
+                        }
                     }
 
                     endpoints.Add( description );
@@ -976,7 +998,16 @@ namespace Opc.Ua
                     settings.Descriptions = endpoints;
                     settings.Configuration = endpointConfiguration;
                     settings.ServerCertificate = this.InstanceCertificate;
-                    //settings.ServerCertificateChain = this.InstanceCertificateChain;
+                    System.Xml.XmlElement configExtension = configuration.Extensions.Find(e => e.Name.Equals("SendCertificateChain"));
+                    if (((configExtension != null && configExtension.InnerText.Equals("False"))))
+                    {
+                        settings.ServerCertificateChain = null;
+
+                    }
+                    else
+                    {
+                        settings.ServerCertificateChain = this.InstanceCertificateChain;
+                    }
                     settings.CertificateValidator = configuration.CertificateValidator.GetChannelValidator();
                     settings.NamespaceUris = this.MessageContext.NamespaceUris;
                     settings.Factory = this.MessageContext.Factory;
@@ -1099,17 +1130,28 @@ namespace Opc.Ua
 
                     description.EndpointUrl = uri.ToString();
                     description.Server = serverDescription;
-                    description.ServerCertificate = InstanceCertificate.RawData;
+                    //description.ServerCertificate = InstanceCertificate.RawData;
 
-                    //if (InstanceCertificateChain != null)
-                    //{
-                    //    List<byte> certificateChainList = new List<byte>();
-                    //    for (int i = 0; i < InstanceCertificateChain.Count; i++)
-                    //    {
-                    //        certificateChainList.AddRange(InstanceCertificateChain[i].RawData);
-                    //    }
-                    //    description.ServerCertificate = certificateChainList.ToArray();
-                    //}
+                    if (InstanceCertificateChain != null)
+                    {
+                        List<byte> certificateChainList = new List<byte>();
+
+                        System.Xml.XmlElement configExtension = configuration.Extensions.Find(e => e.Name.Equals("SendCertificateChain"));
+                        if ((configExtension == null || (configExtension != null && configExtension.InnerText.Equals("False"))))
+                        {
+                            certificateChainList.AddRange(InstanceCertificateChain[0].RawData);
+                        }
+                        else
+                        {
+                            for (int i = 0; i < InstanceCertificateChain.Count; i++)
+                            {
+                                certificateChainList.AddRange(InstanceCertificateChain[i].RawData);
+                            }
+                        }
+                        
+                        description.ServerCertificate = certificateChainList.ToArray();
+                    }
+
                     
                     description.SecurityMode = bestPolicy.SecurityMode;
                     description.SecurityPolicyUri = bestPolicy.SecurityPolicyUri;
@@ -1124,16 +1166,25 @@ namespace Opc.Ua
 
                     description.EndpointUrl = uri.ToString();
                     description.Server = serverDescription;
-                    description.ServerCertificate = InstanceCertificate.RawData;
-                    //if (InstanceCertificateChain != null)
-                    //{
-                    //    List<byte> certificateChainList = new List<byte>();
-                    //    for (int i = 0; i < InstanceCertificateChain.Count; i++)
-                    //    {
-                    //        certificateChainList.AddRange(InstanceCertificateChain[i].RawData);
-                    //    }
-                    //    description.ServerCertificate = certificateChainList.ToArray();
-                    //}
+					//description.ServerCertificate = InstanceCertificate.RawData;					
+					
+                    if (InstanceCertificateChain != null)
+                    {
+                        List<byte> certificateChainList = new List<byte>();
+                        System.Xml.XmlElement configExtension = configuration.Extensions.Find(e => e.Name.Equals("SendCertificateChain"));
+                        if ((configExtension == null || (configExtension != null && configExtension.InnerText.Equals("False"))))
+                        {
+                            certificateChainList.AddRange(InstanceCertificateChain[0].RawData);
+                        }
+                        else
+                        {
+                            for (int i = 0; i < InstanceCertificateChain.Count; i++)
+                            {
+                                certificateChainList.AddRange(InstanceCertificateChain[i].RawData);
+                            }
+                        }
+                        description.ServerCertificate = certificateChainList.ToArray();
+                    }
 
                     description.SecurityMode = MessageSecurityMode.None;
                     description.SecurityPolicyUri = SecurityPolicies.None;
@@ -1152,7 +1203,16 @@ namespace Opc.Ua
                     settings.Descriptions = endpoints;
                     settings.Configuration = endpointConfiguration;
                     settings.ServerCertificate = this.InstanceCertificate;
-                    //settings.ServerCertificateChain = this.InstanceCertificateChain;
+                    //build chain only if the flag for sending certificate chain is set to true within the configuration
+                    System.Xml.XmlElement configExtension = configuration.Extensions.Find(e => e.Name.Equals("SendCertificateChain"));
+                    if (((configExtension != null && configExtension.InnerText.Equals("True"))))
+                    {
+                        settings.ServerCertificateChain = this.InstanceCertificateChain;
+                    }
+                    else
+                    {
+                        settings.ServerCertificateChain = null;
+                    }
                     settings.CertificateValidator = configuration.CertificateValidator.GetChannelValidator();
                     settings.NamespaceUris = this.MessageContext.NamespaceUris;
                     settings.Factory = this.MessageContext.Factory;
@@ -1615,13 +1675,19 @@ namespace Opc.Ua
             }
 
             //load certificate chain
-            //InstanceCertificateChain = new X509Certificate2Collection(InstanceCertificate);
-            //List<CertificateIdentifier> issuers = new List<CertificateIdentifier>();
-            //configuration.CertificateValidator.GetIssuers(InstanceCertificate, issuers);
-            //for (int i = 0; i < issuers.Count; i++)
-            //{
-            //    InstanceCertificateChain.Add(issuers[i].Certificate);
-            //}
+            InstanceCertificateChain = new X509Certificate2Collection(InstanceCertificate);
+            List<CertificateIdentifier> issuers = new List<CertificateIdentifier>();
+            //only search issuer if not self-signed
+            if (!Utils.CompareDistinguishedName(InstanceCertificate.Subject, InstanceCertificate.Issuer))
+            {
+                configuration.CertificateValidator.GetIssuers(InstanceCertificate, issuers);
+
+                
+                for (int i = 0; i < issuers.Count; i++)
+                {
+                    InstanceCertificateChain.Add(issuers[i].Certificate);
+                }
+            }
             
             // use the message context from the configuration to ensure the channels are using the same one.
             MessageContext = configuration.CreateMessageContext();
@@ -1883,7 +1949,7 @@ namespace Opc.Ua
         private object m_serverError;
         private object m_certificateValidator;
         private object m_instanceCertificate;
-        //private X509Certificate2Collection m_instanceCertificateChain;
+        private X509Certificate2Collection m_instanceCertificateChain;
         private object m_serverProperties;
         private object m_configuration;
         private object m_serverDescription;

--- a/Stack/Core/Stack/Tcp/TcpChannel.Asymmetric.cs
+++ b/Stack/Core/Stack/Tcp/TcpChannel.Asymmetric.cs
@@ -105,11 +105,11 @@ namespace Opc.Ua.Bindings
         /// <value>
         /// The client certificate chain.
         /// </value>
-        //internal X509Certificate2Collection ClientCertificateChain
-        //{
-        //    get { return m_clientCertificateChain; }
-        //    set { m_clientCertificateChain = value; }
-        //}
+        internal X509Certificate2Collection ClientCertificateChain
+        {
+            get { return m_clientCertificateChain; }
+            set { m_clientCertificateChain = value; }
+        }
 
         /// <summary>
         /// Gets or sets the server certificate chain.
@@ -117,11 +117,11 @@ namespace Opc.Ua.Bindings
         /// <value>
         /// The server certificate chain.
         /// </value>
-        //internal X509Certificate2Collection ServerCertificateChain
-        //{
-        //    get { return m_serverCertificateChain; }
-        //    set { m_serverCertificateChain = value; }
-        //}
+        internal X509Certificate2Collection ServerCertificateChain
+        {
+            get { return m_serverCertificateChain; }
+            set { m_serverCertificateChain = value; }
+        }
                 
         /// <summary>
         /// Creates a new nonce.
@@ -466,7 +466,7 @@ namespace Opc.Ua.Bindings
         }
 
 
-        /*protected void WriteAsymmetricMessageHeader(
+        protected void WriteAsymmetricMessageHeader(
             BinaryEncoder encoder,
             uint messageType,
             uint secureChannelId,
@@ -522,7 +522,7 @@ namespace Opc.Ua.Bindings
                     encoder.Position - start,
                     SendBufferSize);
             }
-        }*/
+        }
 
         private int GetMaxSenderCertificateSize(X509Certificate2 senderCertificate, string securityPolicyUri)
         {
@@ -723,7 +723,7 @@ namespace Opc.Ua.Bindings
         }
 
 
-        /*protected BufferCollection WriteAsymmetricMessage(
+        protected BufferCollection WriteAsymmetricMessage(
             uint messageType,
             uint requestId,
             X509Certificate2Collection senderCertificates,
@@ -901,7 +901,7 @@ namespace Opc.Ua.Bindings
                     chunksToSend.Release(BufferManager, "WriteAsymmetricMessage");
                 }
             }
-        }*/
+        }
 
         /// <summary>
         /// Reads the asymmetric security header to the buffer.
@@ -982,7 +982,7 @@ namespace Opc.Ua.Bindings
             }
         }
 
-        /*protected void ReadAsymmetricMessageHeader(
+        protected void ReadAsymmetricMessageHeader(
             BinaryDecoder decoder,
             X509Certificate2 receiverCertificate,
             out uint secureChannelId,
@@ -1056,7 +1056,7 @@ namespace Opc.Ua.Bindings
                 }
             }
         }
-        */
+        
         
         /// <summary>
         /// Checks if it is possible to revise the security mode.
@@ -1146,26 +1146,27 @@ namespace Opc.Ua.Bindings
             
             string securityPolicyUri = null;
 
-            //X509Certificate2Collection senderCertificateChain;
+            X509Certificate2Collection senderCertificateChain;
             // parse the security header.
             ReadAsymmetricMessageHeader(
                 decoder,
                 receiverCertificate,
                 out channelId,
-                out senderCertificate,
+				out senderCertificateChain,
+                //out senderCertificate,
                 out securityPolicyUri);
 
-            /*senderCertificate = null;
+            senderCertificate = null;
             if (senderCertificateChain != null && senderCertificateChain.Count > 0)
             {
                 senderCertificate = senderCertificateChain[0];
-            }*/
+            }
 
             // validate the sender certificate.
             if (senderCertificate != null && Quotas.CertificateValidator != null && securityPolicyUri != SecurityPolicies.None)
             {
-                //(Quotas.CertificateValidator as Opc.Ua.CertificateValidator.WcfValidatorWrapper).Validate(senderCertificateChain);
-                Quotas.CertificateValidator.Validate(senderCertificate);
+                (Quotas.CertificateValidator as Opc.Ua.CertificateValidator.WcfValidatorWrapper).Validate(senderCertificateChain);
+                //Quotas.CertificateValidator.Validate(senderCertificate);
             }
                  
             // check if this is the first open secure channel request.
@@ -1463,8 +1464,8 @@ namespace Opc.Ua.Bindings
         private EndpointDescription m_selectedEndpoint;
         private X509Certificate2 m_serverCertificate;   
         private X509Certificate2 m_clientCertificate;
-        //private X509Certificate2Collection m_serverCertificateChain;
-        //private X509Certificate2Collection m_clientCertificateChain;
+        private X509Certificate2Collection m_serverCertificateChain;
+        private X509Certificate2Collection m_clientCertificateChain;
         private RNGCryptoServiceProvider m_random;
         private bool m_uninitialized;
         #endregion

--- a/Stack/Core/Stack/Tcp/TcpClientChannel.cs
+++ b/Stack/Core/Stack/Tcp/TcpClientChannel.cs
@@ -481,15 +481,29 @@ namespace Opc.Ua.Bindings
             // encode the request.            
             byte[] buffer = BinaryEncoder.EncodeMessage(request, Quotas.MessageContext); 
 
+			BufferCollection chunksToSend;
+			
             // write the asymmetric message.
-            BufferCollection chunksToSend = WriteAsymmetricMessage(
+             if (ClientCertificateChain != null)
+            {
+                chunksToSend = WriteAsymmetricMessage(
+                TcpMessageType.Open,
+                m_handshakeOperation.RequestId,
+                ClientCertificateChain,
+                //ClientCertificate,
+                ServerCertificate,
+                new ArraySegment<byte>(buffer, 0, buffer.Length));
+            }else
+            {
+                chunksToSend = WriteAsymmetricMessage(
                 TcpMessageType.Open,
                 m_handshakeOperation.RequestId,
                 //ClientCertificateChain,
                 ClientCertificate,
                 ServerCertificate,
                 new ArraySegment<byte>(buffer, 0, buffer.Length));
-
+            }
+            
             // save token.
             m_requestedToken = token;
             

--- a/Stack/Core/Stack/Tcp/TcpListener.cs
+++ b/Stack/Core/Stack/Tcp/TcpListener.cs
@@ -143,7 +143,7 @@ namespace Opc.Ua.Bindings
 
             // save the server certificate.
             m_serverCertificate = settings.ServerCertificate;
-            //m_serverCertificateChain = settings.ServerCertificateChain;
+            m_serverCertificateChain = settings.ServerCertificateChain;
 
             m_bufferManager = new BufferManager("Server", (int)Int32.MaxValue, m_quotas.MaxBufferSize);
             m_channels = new Dictionary<uint, TcpServerChannel>();
@@ -342,7 +342,7 @@ namespace Opc.Ua.Bindings
                         m_quotas,
                         m_serverCertificate,
                         m_descriptions);
-                    //channel.ServerCertificateChain = m_serverCertificateChain;
+                    channel.ServerCertificateChain = m_serverCertificateChain;
 
                     // start accepting messages on the channel.
                     channel.Attach(++m_lastChannelId, socket);
@@ -402,7 +402,7 @@ namespace Opc.Ua.Bindings
                         m_quotas,
                         m_serverCertificate,
                         m_descriptions);
-                    //channel.ServerCertificateChain = m_serverCertificateChain;
+                    channel.ServerCertificateChain = m_serverCertificateChain;
 
                     // start accepting messages on the channel.
                     channel.Attach(++m_lastChannelId, socket);
@@ -525,7 +525,7 @@ namespace Opc.Ua.Bindings
         private TcpChannelQuotas m_quotas;
         private X509Certificate2 m_serverCertificate;
 
-        //private X509Certificate2Collection m_serverCertificateChain;
+        private X509Certificate2Collection m_serverCertificateChain;
         private uint m_lastChannelId;
 
         private Socket m_listeningSocket;

--- a/Stack/Core/Stack/Tcp/TcpServerChannel.cs
+++ b/Stack/Core/Stack/Tcp/TcpServerChannel.cs
@@ -975,15 +975,29 @@ namespace Opc.Ua.Bindings
             response.SecurityToken.RevisedLifetime = (uint)token.Lifetime;
             response.ServerNonce = token.ServerNonce;
             
-            byte[] buffer = BinaryEncoder.EncodeMessage(response, Quotas.MessageContext); 
-            
-            BufferCollection chunksToSend = WriteAsymmetricMessage(
-                TcpMessageType.Open,
-                requestId,
-                //ServerCertificateChain,
-                ServerCertificate,
-                ClientCertificate,
-                new ArraySegment<byte>(buffer, 0, buffer.Length));
+            byte[] buffer = BinaryEncoder.EncodeMessage(response, Quotas.MessageContext);
+            BufferCollection chunksToSend = null;
+            if (ServerCertificateChain != null)
+            {
+                chunksToSend = WriteAsymmetricMessage(
+                    TcpMessageType.Open,
+                    requestId,
+                    ServerCertificateChain,
+                    //ServerCertificate,
+                    ClientCertificate,
+                    new ArraySegment<byte>(buffer, 0, buffer.Length));
+            }
+            else
+            {
+                chunksToSend = WriteAsymmetricMessage(
+                                    TcpMessageType.Open,
+                                    requestId,
+                                    //ServerCertificateChain,
+                                    ServerCertificate,
+                                    ClientCertificate,
+                                    new ArraySegment<byte>(buffer, 0, buffer.Length));
+
+            }
 
             // write the message to the server.
             try

--- a/Stack/Core/Stack/Tcp/TcpTransportChannel.cs
+++ b/Stack/Core/Stack/Tcp/TcpTransportChannel.cs
@@ -380,11 +380,11 @@ namespace Opc.Ua.Bindings
                 Guid.NewGuid().ToString(),
                 m_bufferManager,
                 m_quotas,
-                m_settings.ClientCertificate,
+                m_settings.ClientCertificateChain==null? m_settings.ClientCertificate: m_settings.ClientCertificateChain[0],
                 m_settings.ServerCertificate,
                 m_settings.Description);
 
-            //((TcpClientChannel)m_channel).ClientCertificateChain = m_settings.ClientCertificateChain;
+            ((TcpClientChannel)m_channel).ClientCertificateChain = m_settings.ClientCertificateChain;
 
             // begin connect operation.
             // IAsyncResult result = m_channel.BeginConnect(m_url, m_operationTimeout, null, null);

--- a/Stack/Core/Stack/Transport/TransportChannelSettings.cs
+++ b/Stack/Core/Stack/Transport/TransportChannelSettings.cs
@@ -63,11 +63,11 @@ namespace Opc.Ua
         /// <value>
         /// The client certificate chain.
         /// </value>
-        //public X509Certificate2Collection ClientCertificateChain
-        //{
-        //    get { return m_clientCertificateChain; }
-        //    set { m_clientCertificateChain = value; }
-        //}
+        public X509Certificate2Collection ClientCertificateChain
+        {
+            get { return m_clientCertificateChain; }
+            set { m_clientCertificateChain = value; }
+        }
 
         /// <summary>
         /// Gets or Sets the server certificate.
@@ -135,7 +135,7 @@ namespace Opc.Ua
         private EndpointDescription m_description;
         private EndpointConfiguration m_configuration;
         private X509Certificate2 m_clientCertificate;
-        //private X509Certificate2Collection m_clientCertificateChain;
+        private X509Certificate2Collection m_clientCertificateChain;
         private X509Certificate2 m_serverCertificate;
         private X509CertificateValidator m_certificateValidator;
         private NamespaceTable m_namespaceUris;

--- a/Stack/Core/Stack/Transport/TransportListenerSettings.cs
+++ b/Stack/Core/Stack/Transport/TransportListenerSettings.cs
@@ -61,11 +61,11 @@ namespace Opc.Ua
         /// <value>
         /// The server certificate chain.
         /// </value>
-        //public X509Certificate2Collection ServerCertificateChain
-        //{
-        //    get { return m_serverCertificateChain; }
-        //    set { m_serverCertificateChain = value; }
-        //}
+        public X509Certificate2Collection ServerCertificateChain
+        {
+            get { return m_serverCertificateChain; }
+            set { m_serverCertificateChain = value; }
+        }
 
         /// <summary>
         /// Gets or Sets the certificate validator.
@@ -122,7 +122,7 @@ namespace Opc.Ua
         private EndpointDescriptionCollection m_descriptions;
         private EndpointConfiguration m_configuration;
         private X509Certificate2 m_serverCertificate;
-        //private X509Certificate2Collection m_serverCertificateChain;
+        private X509Certificate2Collection m_serverCertificateChain;
         private X509CertificateValidator m_certificateValidator;
         private NamespaceTable m_namespaceUris;
         private EncodeableFactory m_channelFactory;

--- a/UA Sample Applications.sln
+++ b/UA Sample Applications.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{A579C6F2-2C5F-4176-BEAE-0D1BD0750375}"
 EndProject
@@ -62,7 +62,6 @@ Global
 		{D71697DF-05D4-481A-B320-D2398F2192C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D71697DF-05D4-481A-B320-D2398F2192C3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B109EBAE-BB08-40A7-BB9E-7E56B9151B17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B109EBAE-BB08-40A7-BB9E-7E56B9151B17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B109EBAE-BB08-40A7-BB9E-7E56B9151B17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B109EBAE-BB08-40A7-BB9E-7E56B9151B17}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1B5BADAA-EA40-47B0-A4BF-C5D39FB237EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
There was some code in the SDK which was commented out and which obviously was supposed to 
i) enable the applications to accept certificate chains (or parts of them) sent to them by the other party and use these parts for certificate validation
ii) enable the applications to send certificate chains or parts of them

After removing the comments from the relevant code certificate validation would not work as expected, in particular for self-signed certificates (they were not recognized as complete chains). Therefore we changed the certificate validation code in the validate() method of the CertificateValidator class and added a new method to be called from within validate().

In addition it is not desirable to send certificate chains by default, the other application might not be able to deal with that. So both in the server (SeverBase.cs) as well as in the client code (Session.cs) we introduced a configuration switch in order to enable/disable sending of certificate chains. The default is to not send a chain. This switch is implemented using the Extensions attribute of the ApplicationConfiguration.

The changes work well with our application, but seem to break the sample applications in two respects: enabling the application to receive certificate chains will result in the application to verify the whole chain at startup. Enabling sending the certificate chains does not seem to work since the changes are in session.create(), which seemingly is not called by all the samples (they seem to call open() directly). Enabling the server(s) to send certificate chains seems to work fine.

We decided to publish the changes nonetheless since most of the files we changed are licensed under the RCL and since we think that the ability to deal with certificate chains sent to an OPC UA application is important.

Expected behavior: when an OPC UA server or client receives an application certificate together with some CA certificates, it will merge these CA certificates into the chain it builds during certificate validation. For successful validation one certificate in the chain has to be found in the trust store, the rest has to be present either in the part which was sent to it or in the pertaining stores on it's own host. When sending certificate chains is enabled the application searches for CA certificates used to sign its own application certificate and recursively searches for further CA certificates which have been used for signing other certificates in the chain. It will then send all certificates found to the other party, together with the application certificate.