### PR TITLE
Fixed SendCertificateChain

### DIFF
--- a/SampleApplications/SampleLibraries/Client/Session.cs
+++ b/SampleApplications/SampleLibraries/Client/Session.cs
@@ -779,10 +779,11 @@ namespace Opc.Ua.Client
 
                 clientCertificate = configuration.SecurityConfiguration.ApplicationCertificate.Find( true );
 
-				if( clientCertificate == null )
-				{
+                if ( clientCertificate == null )
+                {
                     throw ServiceResultException.Create( StatusCodes.BadConfigurationError, "ApplicationCertificate cannot be found." );
-                }else
+                }
+                else
                 {
                     //load certificate chain
                     List<CertificateIdentifier> issuers = new List<CertificateIdentifier>();
@@ -803,40 +804,46 @@ namespace Opc.Ua.Client
             ITransportChannel channel = null;
 
             //read sendCertificateChain option from configuration
-            string sendCertificateChainOption = (configuration.Extensions.Find(e => e.Name.Equals("sendCertificateChain")).InnerText);
-
-            if (clientCertificateChain != null && sendCertificateChainOption.Equals("True"))
+            if (clientCertificateChain != null)
             {
-                
-                 channel = SessionChannel.Create(
-                 configuration,
-                 endpointDescription,
-                 endpointConfiguration,
-                 clientCertificateChain,
-                 messageContext);
-            }else
-            {                
+                XmlElement configExtension = null;
+                if (configuration.Extensions != null)
+                {
+                    configExtension = configuration.Extensions.Find(e => "SendCertificateChain".Equals(e.Name, StringComparison.InvariantCultureIgnoreCase));
+                }
+                if (configExtension != null && "true".Equals(configExtension.InnerText, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    channel = SessionChannel.Create(
+                        configuration,
+                        endpointDescription,
+                        endpointConfiguration,
+                        clientCertificateChain,
+                        messageContext);
+                }
+            }
+
+            if (channel == null) {
                 channel = SessionChannel.Create(
-                configuration,
-                endpointDescription,
-                endpointConfiguration,
-                clientCertificate,
-                messageContext);
+                    configuration,
+                    endpointDescription,
+                    endpointConfiguration,
+                    clientCertificate,
+                    messageContext);
             }
 
             // create the session object.
             Session session = new Session(channel, configuration, endpoint, null);
 
             // create the session.
-			try
-			{
-				session.Open( sessionName, sessionTimeout, identity, preferredLocales, checkDomain );
-			}
-			catch
-			{
-				session.Dispose();
-				throw;
-			}
+            try
+            {
+                session.Open( sessionName, sessionTimeout, identity, preferredLocales, checkDomain );
+            }
+            catch
+            {
+                session.Dispose();
+                throw;
+            }
 
             return session;
         }

--- a/Stack/Core/Stack/Server/ServerBase.cs
+++ b/Stack/Core/Stack/Server/ServerBase.cs
@@ -1136,17 +1136,21 @@ namespace Opc.Ua
                     {
                         List<byte> certificateChainList = new List<byte>();
 
-                        System.Xml.XmlElement configExtension = configuration.Extensions.Find(e => e.Name.Equals("SendCertificateChain"));
-                        if ((configExtension == null || (configExtension != null && configExtension.InnerText.Equals("False"))))
-                        {
-                            certificateChainList.AddRange(InstanceCertificateChain[0].RawData);
+                        System.Xml.XmlElement configExtension = null;
+                        if (configuration.Extensions != null)
+												{
+                            configExtension = configuration.Extensions.Find(e => "SendCertificateChain".Equals(e.Name, StringComparison.InvariantCultureIgnoreCase));
                         }
-                        else
+                        if (configExtension != null && "true".Equals(configExtension.InnerText, StringComparison.InvariantCultureIgnoreCase))
                         {
                             for (int i = 0; i < InstanceCertificateChain.Count; i++)
                             {
                                 certificateChainList.AddRange(InstanceCertificateChain[i].RawData);
                             }
+                        }
+                        else
+                        {
+                            certificateChainList.AddRange(InstanceCertificateChain[0].RawData);
                         }
                         
                         description.ServerCertificate = certificateChainList.ToArray();


### PR DESCRIPTION
Adjusted SendCertificateChain support to
- not throw a NullPointerException on missing configExtension
- default to false if no option or an invalid value is given
- comparison changed to InvariantCultureIgnoreCase