### PR TITLE
Delete reference from target

### DIFF
--- a/SampleApplications/SampleLibraries/Server/Diagnostics/CustomNodeManager.cs
+++ b/SampleApplications/SampleLibraries/Server/Diagnostics/CustomNodeManager.cs
@@ -670,7 +670,7 @@ namespace Opc.Ua.Server
                 LocalReference referenceToRemove = new LocalReference(
                     (NodeId)reference.TargetId,
                     reference.ReferenceTypeId,
-                    reference.IsInverse,
+                    !reference.IsInverse,
                     node.NodeId);
 
                 referencesToRemove.Add(referenceToRemove);


### PR DESCRIPTION
When the session closed,I find SessionsDiagnosticsSummaryState didn't delete the SessionDiagnosticsObjectState reference