### PR TITLE
Allow external logging

### DIFF
--- a/Stack/Core/Types/Utils/Utils.cs
+++ b/Stack/Core/Types/Utils/Utils.cs
@@ -2910,7 +2910,7 @@ namespace Opc.Ua
         /// <summary>
         /// Internal Singleton Instance getter.
         /// </summary>
-        internal static Tracing Instance
+        public static Tracing Instance
         {
             get
             {


### PR DESCRIPTION
Changed singleton accesslevel to public so that it can be accessed by external code to log in their native methodology