### PR TITLE
UA-.NET on MonoDevelop 5.9.6 under Unity3D 5.5.0f3

### DIFF
--- a/Stack/Core/Stack/Bindings/BufferManager.cs
+++ b/Stack/Core/Stack/Bindings/BufferManager.cs
@@ -135,7 +135,13 @@ namespace Opc.Ua.Bindings
         /// <param name="owner">The owner.</param>
         /// <returns>The buffer content</returns>
         public byte[] TakeBuffer(int size, string owner)
-        {
+        {   
+						#if ELBFISCH //#define ELBFISCH if you want to compile this code for Mono/.NET 3.5 (for use in Unity3D 5.5) 
+						//a size of 65535 which is given by several owners for any reason fails at runtime
+						if (size > 65534) {
+							size = 65534;
+						}
+					  #endif
             if (size > Int32.MaxValue - 5)
             {
                 throw new ArgumentOutOfRangeException("size");

--- a/Stack/Core/Types/Encoders/BinaryDecoder.cs
+++ b/Stack/Core/Types/Encoders/BinaryDecoder.cs
@@ -466,8 +466,11 @@ namespace Opc.Ua
             XmlDocument document = new XmlDocument();
             string xmlString = new UTF8Encoding().GetString(bytes, 0, bytes.Length);
 
-            using (XmlReader reader = XmlReader.Create(new StringReader(xmlString), new XmlReaderSettings()
-                {DtdProcessing = System.Xml.DtdProcessing.Prohibit, ValidationType = ValidationType.None}))
+			using (XmlReader reader = XmlReader.Create(new StringReader(xmlString), new XmlReaderSettings()
+				#if !ELBFISCH //#define ELBFISCH if you want to compile this code for Mono/.NET 3.5 (for use in Unity3D 5.5)
+				 {DtdProcessing = System.Xml.DtdProcessing.Prohibit, ValidationType = ValidationType.None}
+				#endif
+			))
             {
                 document.Load(reader);
             }

--- a/Stack/Core/Types/Encoders/XmlDecoder.cs
+++ b/Stack/Core/Types/Encoders/XmlDecoder.cs
@@ -558,7 +558,10 @@ namespace Opc.Ua
                 xmlString = m_reader.ReadOuterXml();
 
                 using (XmlReader reader = XmlReader.Create(new StringReader(xmlString), new XmlReaderSettings() 
-                    { DtdProcessing = System.Xml.DtdProcessing.Prohibit, ValidationType = ValidationType.None }))
+					#if !ELBFISCH //#define ELBFISCH if you want to compile this code for Mono/.NET 3.5 (for use in Unity3D 5.5)
+					{ DtdProcessing = System.Xml.DtdProcessing.Prohibit, ValidationType = ValidationType.None }
+					#endif
+				))
                 {
                     document.Load(reader);
                 }
@@ -585,7 +588,10 @@ namespace Opc.Ua
             xmlString = m_reader.ReadOuterXml();
 
             using (XmlReader reader = XmlReader.Create(new StringReader(xmlString), new XmlReaderSettings() 
-                { DtdProcessing = System.Xml.DtdProcessing.Prohibit, ValidationType = ValidationType.None }))
+				#if !ELBFISCH //#define ELBFISCH if you want to compile this code for Mono/.NET 3.5 (for use in Unity3D 5.5)
+				{ DtdProcessing = System.Xml.DtdProcessing.Prohibit, ValidationType = ValidationType.None }
+				#endif
+			))
             {
                 document.Load(reader);
             }

--- a/Stack/Core/Types/Utils/HiResClock.cs
+++ b/Stack/Core/Types/Utils/HiResClock.cs
@@ -33,7 +33,7 @@ namespace Opc.Ua
         {
             get
             {
-                #if !SILVERLIGHT
+								#if (!SILVERLIGHT && !ELBFISCH) //#define ELBFISCH if you want to compile this code for Mono/.NET 3.5 (for use in Unity3D 5.5)
                 if (s_Default.m_disabled)
                 {
                     return DateTime.UtcNow;
@@ -41,7 +41,7 @@ namespace Opc.Ua
 
                 long counter = 0;
 
-                if (NativeMethods.QueryPerformanceCounter(out counter) == 0)
+	           		if (NativeMethods.QueryPerformanceCounter(out counter) == 0)
                 {
                     return DateTime.UtcNow;
                 }
@@ -71,12 +71,12 @@ namespace Opc.Ua
             }
         }
 
-        /// <summary>
+		/// <summary>
         /// Constructs a class.
         /// </summary>
         private HiResClock()
         {
-            #if !SILVERLIGHT
+			#if (!SILVERLIGHT && !ELBFISCH) //#define ELBFISCH if you want to compile this code for Mono/.NET 3.5 (for use in Unity3D 5.5)
             if (NativeMethods.QueryPerformanceFrequency(out m_frequency) == 0)
             {
                 m_frequency = TimeSpan.TicksPerSecond;
@@ -101,7 +101,8 @@ namespace Opc.Ua
         /// <summary>
         /// Defines the native methods used by the class.
         /// </summary>
-        private static class NativeMethods
+		#if !ELBFISCH
+		private static class NativeMethods
         {
             [DllImport("Kernel32.dll")]
             public static extern int QueryPerformanceFrequency(out long lpFrequency);
@@ -109,8 +110,9 @@ namespace Opc.Ua
             [DllImport("Kernel32.dll")]
             public static extern int QueryPerformanceCounter(out long lpFrequency);
         }
+		#endif
         
-        #if !SILVERLIGHT
+		#if !SILVERLIGHT && !ELBFISCH //#define ELBFISCH if you want to compile this code for Mono/.NET 3.5 (for use in Unity3D 5.5)
         private long m_frequency;
         private long m_baseline;
         private long m_offset;

--- a/Stack/Core/UA Core Library.csproj
+++ b/Stack/Core/UA Core Library.csproj
@@ -1,16 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{7543AFCB-F5AF-44AF-83C9-23164474C1E9}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Opc.Ua</RootNamespace>
     <AssemblyName>Opc.Ua.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Key\OPC Key Pair.snk</AssemblyOriginatorKeyFile>
@@ -41,12 +39,10 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;ELBFISCH</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
-    <DocumentationFile>
-    </DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -61,7 +57,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
@@ -83,6 +78,7 @@
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Documentation\Opc.Ua.Bindings.cs" />

--- a/UA Core Library.userprefs
+++ b/UA Core Library.userprefs
@@ -1,0 +1,12 @@
+﻿<Properties StartupItem="Stack/Core/UA Core Library.csproj">
+  <MonoDevelop.Ide.Workspace ActiveConfiguration="Debug" />
+  <MonoDevelop.Ide.Workbench ActiveDocument="Stack/Core/Types/Encoders/BinaryDecoder.cs">
+    <Files>
+      <File FileName="Stack/Core/Types/Encoders/BinaryDecoder.cs" Line="471" Column="7" />
+    </Files>
+  </MonoDevelop.Ide.Workbench>
+  <MonoDevelop.Ide.DebuggingService.Breakpoints>
+    <BreakpointStore />
+  </MonoDevelop.Ide.DebuggingService.Breakpoints>
+  <MonoDevelop.Ide.DebuggingService.PinnedWatches />
+</Properties>


### PR DESCRIPTION
made some slight changes to make the library work with MonoDevelop 5.9.6 under Unity3D 5.5.0f3. Useful to connect an Unity3D application to a PLC via OPC/UA