### PR TITLE
Reworked logic of registering async requests in Session.m_outstandingRequests

### DIFF
--- a/SampleApplications/SampleLibraries/Client/Session.cs
+++ b/SampleApplications/SampleLibraries/Client/Session.cs
@@ -3369,21 +3369,18 @@ namespace Opc.Ua.Client
             lock (m_outstandingRequests)
             {
                 // check if the request completed asynchronously.
-                AsyncRequestState state = RemoveRequest(result, requestId, typeId);
-                
-                // add a new request.
-                if (state == null)
-                {
-                    state = new AsyncRequestState();
+                if (result.IsCompleted)
+                    return;
 
-                    state.Defunct = false;
-                    state.RequestId  = requestId;
-                    state.RequestTypeId = typeId;
-                    state.Result = result;
-                    state.Timestamp = DateTime.UtcNow;
+                // add request
+                AsyncRequestState state = new AsyncRequestState();
+                state.Defunct = false;
+                state.RequestId = requestId;
+                state.RequestTypeId = typeId;
+                state.Result = result;
+                state.Timestamp = DateTime.UtcNow;
 
-                    m_outstandingRequests.AddLast(state);
-                }
+                m_outstandingRequests.AddLast(state);
             }
         }
 
@@ -3396,33 +3393,20 @@ namespace Opc.Ua.Client
             {
                 // remove the request.
                 AsyncRequestState state = RemoveRequest(result, requestId, typeId);
-                
-                if (state != null)
-                {
-                    // mark any old requests as default (i.e. the should have returned before this request).
-                    DateTime maxAge = state.Timestamp.AddSeconds(-1);
 
-                    for (LinkedListNode<AsyncRequestState> ii = m_outstandingRequests.First; ii != null; ii = ii.Next)
-                    {
-                        if (ii.Value.RequestTypeId == typeId && ii.Value.Timestamp < maxAge)
-                        {
-                            ii.Value.Defunct = true;
-                        }
-                    }
-                }
-
-                // add a dummy placeholder since the begin request has not completed yet.
+                // if request was completed before registering in AsyncRequestStarted
                 if (state == null)
+                    return;
+
+                // mark any old requests as default (i.e. the should have returned before this request).
+                DateTime maxAge = state.Timestamp.AddSeconds(-1);
+
+                for (LinkedListNode<AsyncRequestState> ii = m_outstandingRequests.First; ii != null; ii = ii.Next)
                 {
-                    state = new AsyncRequestState();
-
-                    state.Defunct = true;
-                    state.RequestId  = requestId;
-                    state.RequestTypeId = typeId;
-                    state.Result = result;
-                    state.Timestamp = DateTime.UtcNow;
-
-                    m_outstandingRequests.AddLast(state);
+                    if (ii.Value.RequestTypeId == typeId && ii.Value.Timestamp < maxAge)
+                    {
+                        ii.Value.Defunct = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Problem description. 
Keep alive problems on the client side are detected.  This is happening due to m_outstandingRequests count limited as 10 + subscription count (Session.cs p. 3439) and new keep alive requests are not sent if limit reached. 
Bug repeating algorithm: session timeout interval set to 1 hour, subscription publishing interval set to 10 sec, session keepalive interval set to 1 sec. After connection was established turn off network adapter. After 15 failed reconnection attempts there should be 15 "hanged" requests in m_outstandingRequests, now turn on network adapter. Reached limit of m_outstandingRequests will prevent sending addidtional keepalive requests after session reconnecting and right after reconnection keep alive problems detected again. Reconnection starts again and so forth.

Root cause is that during reconnection BeginPublish requests are sent (p. 3667), then immediately callback is called in another thread, where AsyncRequestCompleted is called. At this moment AsyncRequestStarted was not called yet and therefore dummy AsyncRequestState is addded to m_outstandingRequests (p. 3414). Then inside BeginPublish Exception is thrown. As result AsyncRequestStarted method never reached and dummy request  added in AsyncRequestCompleted never removed from m_outstandingRequests. 

To solve the problem it is proposed not to register requests as dummy if AsynRequestCompleted is called earlier than AsyncRequestStarted but instead just skip any registering.  IAsyncResult.IsCompleted flag is always set True before calling completion callback (where AsyncRequestCompleted is called), so racing condition is not possible in AsyncRequestStarted. Latest mentioned fact regarding IsCompleted flag is checked in TcpAsyncOperation.cs and AsyncResultBase.cs files.

P.S. Proposed solution was tested in real Ua client application successfully.